### PR TITLE
Add support for BM3D de-noising in QTGMC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ## Dependent plugins
 - [AddGrain](https://github.com/HomeOfVapourSynthEvolution/VapourSynth-AddGrain)
+- [BM3D](https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D)
 - [CAS](https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CAS)
 - [CTMF](https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CTMF)
 - [DCTFilter](https://github.com/HomeOfVapourSynthEvolution/VapourSynth-DCTFilter)

--- a/havsfunc.py
+++ b/havsfunc.py
@@ -1326,7 +1326,7 @@ def QTGMC(
 
         NoisePreset: Automatic setting for quality of noise processing. Choices: "Slower", "Slow", "Medium", "Fast", and "Faster".
 
-        Denoiser: Select denoiser to use for noise bypass / denoising. Select from "dfttest", "fft3dfilter" or "knlmeanscl".
+        Denoiser: Select denoiser to use for noise bypass / denoising. Select from "bm3d", "dfttest", "fft3dfilter" or "knlmeanscl".
             Unknown value selects "fft3dfilter".
 
         FftThreads: Number of threads to use if using "fft3dfilter" for Denoiser.
@@ -1864,7 +1864,9 @@ def QTGMC(
                     core.mv.Compensate(fullClip, fullSuper, bVec2, thscd1=ThSCD1, thscd2=ThSCD2),
                 ]
             )
-        if Denoiser == 'dfttest':
+        if Denoiser == 'bm3d':
+            dnWindow = mvf.BM3D(noiseWindow, radius1=NoiseTR, sigma=[Sigma if plane in CNplanes else 0 for plane in range(3)])
+        elif Denoiser == 'dfttest':
             dnWindow = noiseWindow.dfttest.DFTTest(sigma=Sigma * 4, tbsize=noiseTD, planes=CNplanes)
         elif Denoiser in ['knlm', 'knlmeanscl']:
             if ChromaNoise and not is_gray:


### PR DESCRIPTION
Specified as lowercase "bm3d". Requires mvsfunc and the BM3D plugin.

In my sampling, denoised noise luma was close to neutral so I didn't add it to the 128.5 special-case handling.