### PR TITLE
Fix LutDeRainbow mask with higher bit depths.

### DIFF
--- a/havsfunc.py
+++ b/havsfunc.py
@@ -3456,7 +3456,7 @@ def LUTDeRainbow(input, cthresh=10, ythresh=10, y=True, linkUV=True, mask=False)
     vmask = average_v.std.Binarize(threshold=21 << shift)
 
     if useExpr:
-        themask = core.std.Expr([umask, vmask], expr=[f'x y +'])
+        themask = core.std.Expr([umask, vmask], expr=[f'x y + {peak + 1} < 0 {peak} ?'])
         if y:
             umask = core.std.MaskedMerge(core.std.BlankClip(average_y), average_y, umask)
             vmask = core.std.MaskedMerge(core.std.BlankClip(average_y), average_y, vmask)


### PR DESCRIPTION
This was a bug of my own committing.

In short, the original Expr logic didn't work as first intended.

We're replacing a bitwise-and, and the original addition approach simply didn't work.

Here's an example:
For two pixels in the binarized mask clips (using 8-bit values for reference, but all bitdepths scale appropriately):

**Expected:**
|x | y | result|
|--|---|-------|
0   | 0   | 0
0   | 255 | 0
255 | 0   | 0
255 | 255 | 255

**Actual (old code for 11+ bit depth)**
Expr = "x y +"
|x | y | result|
|--|---|-------|
0   | 0   | 0
0   | 255 | 255
255 | 0   | 255
255 | 255 | 255 (because Expr clamps to bit depth peak)

**Actual (new code for 11+ bit depth)**
Expr = "x y + (255 + 1) < 0 255 ?"
Aka - if the sum of two pixels is less than the peak + 1 (aka <= the peak), then output 0, else output the peak. I'm simply using "peak + 1" here to save some cycles, taking the "<=" down to just a "<" 
|x | y | result|
|--|---|-------|
0   | 0   | 0
0   | 255 | 0
255 | 0   | 0
255 | 255 | 255 (because Expr clamps to bit depth peak)