### PR TITLE
Update HQDeringmod to make it actually HQ as default (none) is very blurry

### DIFF
--- a/havsfunc.py
+++ b/havsfunc.py
@@ -893,7 +893,7 @@ def HQDeringmod(
     incedge: bool = False,
     mthr: int = 60,
     minp: int = 1,
-    nrmode: Optional[int] = None,
+    nrmode: Optional[int] = 0,
     sigma: float = 128.0,
     sigma2: Optional[float] = None,
     sbsize: Optional[int] = None,


### PR DESCRIPTION
Default options for HQDering uses minblur  which blurs too much.
Dfttest is much better and having HQ actually be default HQ I think is the way to go.
Also fixes #71.