### PR TITLE
QTGMC: Support high bit-depth input with InputType=2

### DIFF
--- a/havsfunc/havsfunc.py
+++ b/havsfunc/havsfunc.py
@@ -2763,7 +2763,8 @@ def QTGMC(
         else:
             edi = edi1
     else:
-        inputTypeBlend = core.mv.Mask(srchClip, bVec1, kind=1, ml=ProgSADMask)
+        inputTypeBlend = core.mv.Mask(depth(srchClip, 8, dither_type=DitherType.NONE), bVec1, kind=1, ml=ProgSADMask)
+        inputTypeBlend = depth(inputTypeBlend, srchClip.format.bits_per_sample, dither_type=DitherType.NONE)
         edi = core.std.MaskedMerge(innerClip, edi1, inputTypeBlend, planes=0)
 
     # Get the max/min value for each pixel over neighboring motion-compensated frames - used for temporal sharpness limiting
@@ -3007,7 +3008,8 @@ def QTGMC(
     elif SBlurLimit <= 0:
         sblurred = sblur
     else:
-        sbMotionMask = core.mv.Mask(srchClip, bVec1, kind=0, ml=SBlurLimit)
+        sbMotionMask = core.mv.Mask(depth(srchClip, 8, dither_type=DitherType.NONE), bVec1, kind=0, ml=SBlurLimit)
+        sbMotionMask = depth(sbMotionMask, srchClip.format.bits_per_sample, dither_type=DitherType.NONE)
         sblurred = core.std.MaskedMerge(addNoise2, sblur, sbMotionMask)
 
     # Reduce frame rate


### PR DESCRIPTION
Fixes error when InputType >= 2, FastMA=False, ProgSADMask=0, and >8-bit input
```py
  File "/usr/lib/python3.12/site-packages/havsfunc/havsfunc.py", line 2766, in QTGMC
    inputTypeBlend = core.mv.Mask(srchClip, bVec1, kind=1, ml=ProgSADMask)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "src/cython/vapoursynth.pyx", line 2969, in vapoursynth.Function.__call__
vapoursynth.Error: Mask: input clip must be GRAY8, YUV420P8, YUV422P8, YUV440P8, or YUV444P8, with constant dimensions.
```