### PR TITLE
Update outdated URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # HAvsFunc
 
 ## Dependent scripts
-- [vsdenoise](https://github.com/Jaded-Encoding-Thaumaturgy/vs-denoise)
-- [vsexprtools](https://github.com/Jaded-Encoding-Thaumaturgy/vs-exprtools)
-- [vsmasktools](https://github.com/Jaded-Encoding-Thaumaturgy/vs-masktools)
-- [vsrgtools](https://github.com/Irrational-Encoding-Wizardry/vs-rgtools)
-- [vstools](https://github.com/Irrational-Encoding-Wizardry/vs-tools)
+- [vs-jetpack](https://github.com/Jaded-Encoding-Thaumaturgy/vs-jetpack)
 
 ## Dependent plugins
 - [AddGrain](https://github.com/HomeOfVapourSynthEvolution/VapourSynth-AddGrain)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,7 @@ classifiers = [
 ]
 dependencies = [
   "VapourSynth>=66",
-  "vsdenoise",
-  "vsexprtools",
-  "vsmasktools",
-  "vsrgtools",
-  "vstools",
+  "vsjetpack",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR:
- Updates the JET urls to the new repo.
- Removes the deprecated usage of *mean_matrix utils.
- Fixes some ruff lint complaints.